### PR TITLE
Add/update metafield timestamp

### DIFF
--- a/src/api/shopify.js
+++ b/src/api/shopify.js
@@ -1,4 +1,4 @@
-import { generateApiUrl, handleError, sendLogs } from "../helpers";
+import { generateApiUrl, handleError, sendLogs, formatUtcDate } from "../helpers";
 
 export class ProductProvider {
 	constructor(clientCredentials, loggerCredentials) {
@@ -70,8 +70,7 @@ export class ProductProvider {
 
 		const currentDate = new Date();
 
-		// Format the date manually
-		const formattedDate = `${currentDate.getUTCHours()}:${currentDate.getUTCMinutes()}:${currentDate.getUTCSeconds()} ${currentDate.getUTCDate()}-${currentDate.getUTCMonth() + 1}-${currentDate.getUTCFullYear()} (UTC)`;
+		const formattedDate = formatUtcDate(currentDate);
 
 		const metafields = [
 			{

--- a/src/api/shopify.js
+++ b/src/api/shopify.js
@@ -15,14 +15,25 @@ export class ProductProvider {
 	 */
 	generateVariantQuery = () => {
 		return `
-			mutation productVariantUpdate($input: ProductVariantInput!) {
+			mutation productVariantUpdate($input: ProductVariantInput!, $metafields: [MetafieldsSetInput!]!) {
 				productVariantUpdate(input: $input) {
 					productVariant {
 						barcode
 					}
+				}
+
+				metafieldsSet(metafields: $metafields) {
+					metafields {
+						key
+						namespace
+						value
+						createdAt
+						updatedAt
+					}
 					userErrors {
 						field
 						message
+						code
 					}
 				}
 			}
@@ -56,10 +67,27 @@ export class ProductProvider {
 		if (!queryInput?.id) return;
 
 		const query = this.generateVariantQuery();
+
+		const currentDate = new Date();
+
+		// Format the date manually
+		const formattedDate = `${currentDate.getUTCHours()}:${currentDate.getUTCMinutes()}:${currentDate.getUTCSeconds()} ${currentDate.getUTCDate()}-${currentDate.getUTCMonth() + 1}-${currentDate.getUTCFullYear()} (UTC)`;
+
+		const metafields = [
+			{
+				namespace: "jam_data",
+				key: "last_updated",
+				ownerId: `${queryInput.id}`,
+				value: formattedDate,
+				type: "single_line_text_field"
+			}
+		];
+
 		const requestBody = {
 			query,
 			variables: {
-				input: queryInput
+				input: queryInput,
+				metafields
 			}
 		};
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -84,3 +84,12 @@ export const generateApiUrl = (shopName, apiVersion = DEFAULT_API_VERSION) => {
 	const version = apiVersion ? apiVersion : DEFAULT_API_VERSION;
 	return `https://${shopName}/admin/api/${version}/graphql.json`;
 };
+
+/**
+ * Format the current UTC date into a string
+ * @param {string} currentDate
+ * @returns {string} - formatted date string
+ */
+export const formatUtcDate = (currentDate) => {
+	return `${currentDate.getUTCHours().toString().padStart(2, "0")}:${currentDate.getUTCMinutes().toString().padStart(2, "0")}:${currentDate.getUTCSeconds().toString().padStart(2, "0")} ${currentDate.getUTCDate()}-${(currentDate.getUTCMonth() + 1).toString().padStart(2, "0")}-${currentDate.getUTCFullYear()} (UTC)`;
+};


### PR DESCRIPTION
### Summary
- Add/update variant metafield JAM Last Updated

### Testing instructions
- Send a POST request to `https://jam-kis6.pro-cess.cc` with
- Authorization header with Basic auth Username: `JAM_KIS6` Password: `1234`
- X-Jam-Auth header with `Basic SkFNX1RFU1RDTElFTlRfREVWOlgxMjM0NQ==`
Request body with existing variant ID and fields to update
{
    "id": "gid://shopify/ProductVariant/40402411389041",
    "barcode": "1234_example",
    "compareAtPrice": "9999"
}
Expect: This variant's metafield to be updated: https://admin.shopify.com/store/framework-wind/products/6931299762289/variants/40402411389041